### PR TITLE
 uwc-docs/.github : Sphinx build Workflow fix

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -28,6 +28,7 @@ jobs:
         cur_dir=`pwd`
         cd $HOME
         git clone $GITHUB_SERVER_URL/$GITHUB_REPOSITORY/ --branch develop --single-branch
+        cd uwc-docs
         cp -r $cur_dir/build/* docs/
         git config --global user.name "${GITHUB_ACTOR}"
         git config --global user.email "${GITHUB_ACTOR}@github.com"


### PR DESCRIPTION
 uwc-docs/.github : Sphinx build Workflow fix

    1. Fix the uwc-docs folder missing in pushYML to enable
      workflow build fine

Signed-off-by: nagdeepgk <nagdeep.gk@intel.com>