### PR TITLE
Reviewed and updated page 04.rst

### DIFF
--- a/source/Pages/page_04.rst
+++ b/source/Pages/page_04.rst
@@ -51,17 +51,17 @@ This section provides steps to install and deploy Universal Wellpad Controller c
    - Prod 
 9. Based on the use case (combination of Universal Wellpad Controller services), select one of the following options: 
 
-   - Basic UWC micro-services without KPI-tactic Application & Sparkplug-Bridge - (Modbus-master TCP & RTU, mqtt-bridge, internal mqtt broker, ETCD server, ETCD UI &        other base EII & UWC services)
-   - Basic UWC micro-services as in option 1 along with KPI-tactic Application (Without Sparkplug-Bridge)
-   - Basic UWC micro-services & KPI-tactic Application along with Sparkplug-Bridge, Sample SamplePublisher and Sample SampleSubscriber
-   - Basic UWC micro-services with Sparkplug-Bridge, Sample SamplePublisher and Sample SampleSubscriber and no KPI-tactic Application
-   - Basic UWC micro-services with Time series micro-services (Telegraf & InfluxDBConnector)
-   - Running Basic UWC micro-services with time series services (Telegraf & InfluxDBCOnnector) along with KPI-tactic app
-   - Running Basic UWC micro-services with time series services (Telegraf & InfluxDBCOnnector) along with Sparkplug service, Sample SamplePublisher and Sample              SampleSubscriber
-   - Running the Sample DB publisher with Telegraf, InfluxDBCOnnector, ZmqBroker & Etcd container
-   - Basic UWC micro-services with Sample SamplePublisher and Sample SampleSubscriber
-   - All modules UWC modules, KPI-tactic Application, SPARKPLUG-BRIDGE, Telegraf, InfluxDBCOnnector, ZmqBroker, Etcd container, Sample SamplePublisher and Sample           SampleSubscriber
-*	Do you want to use pre-build images from public docker hub ?
+   1. Basic UWC micro-services without KPI-tactic Application & Sparkplug-Bridge - (Modbus-master TCP & RTU, mqtt-bridge, internal mqtt broker, ETCD server, ETCD UI &        other base EII & UWC services)
+   2. Basic UWC micro-services as in option 1 along with KPI-tactic Application (Without Sparkplug-Bridge)
+   3. Basic UWC micro-services & KPI-tactic Application along with Sparkplug-Bridge, Sample SamplePublisher and Sample SampleSubscriber
+   4. Basic UWC micro-services with Sparkplug-Bridge, Sample SamplePublisher and Sample SampleSubscriber and no KPI-tactic Application
+   5. Basic UWC micro-services with Time series micro-services (Telegraf & InfluxDBConnector)
+   6. Running Basic UWC micro-services with time series services (Telegraf & InfluxDBCOnnector) along with KPI-tactic app
+   7. Running Basic UWC micro-services with time series services (Telegraf & InfluxDBCOnnector) along with Sparkplug service, Sample SamplePublisher and Sample              SampleSubscriber
+   8. Running the Sample DB publisher with Telegraf, InfluxDBCOnnector, ZmqBroker & Etcd container
+   9. Basic UWC micro-services with Sample SamplePublisher and Sample SampleSubscriber
+   10. All modules UWC modules, KPI-tactic Application, SPARKPLUG-BRIDGE, Telegraf, InfluxDBCOnnector, ZmqBroker, Etcd container, Sample SamplePublisher, and Sample           SampleSubscriber
+    * Do you want to use pre-build images from public docker hub ?
     - Yes  
     - No
 
@@ -133,9 +133,9 @@ Build scripts descriptions
     1. 01_uwc_pre_requisites.sh - This script creates docker volume directory /opt/intel/eii/uwc_data, creates “/opt/intel/eii/container_logs/” for storing log, and git clone modconn into respective directory of the Modbus master container.  
     
     2. 02_provision_build_UWC.sh - This script runs the builder to generate the consolidated docker-compose.yml. This script performs provisioning per the docker-compose.yml file. Along with this, it generates certs for the MQTT and builds all the microservices of the docker-compose.yml.
-        It allows you to choose combination of UWC services, deployment mode either dev or prod mode, or select whether to use the `pre-build images` or `build images locally`.
+        It allows you to choose combination of Universal Wellpad Controller services, deployment mode either dev or prod mode, or select whether to use the `pre-build images` or `build images locally`.
 
-    3. 03_Run_UWC.sh - This script deploys all UWC containers.
+    3. 03_Run_UWC.sh - This script deploys all Universal Wellpad Controller containers.
 
     4. 04_uninstall_UWC.sh – Used for cleanup and uninstalling docker, docker-compose, and installed libraries. This script will bring down all containers and remove all running containers.
 
@@ -145,4 +145,4 @@ Build scripts descriptions
 
 .. note::
 
-To change the use case that is running, then rerun the "./02_provision_build_UWC.sh" script. This will remove or kill all the containers of the existing use case and recreate the consolidated docker-compose.yml and consolidated eii_config.json file per the new use case selected in the "./02_provision_build_UWC.sh" script. Provisioning is also done as part of this script. Run the "03_Run_UWC.sh" script after running the "02_provision_build_UWC.sh" script. This will build the containers of the new use case.
+Rerun the "./02_provision_build_UWC.sh" script to change the use case that is running. This will remove or kill all the containers of the existing use case and recreate the consolidated docker-compose.yml and consolidated eii_config.json file per the new use case selected in the "./02_provision_build_UWC.sh" script. Provisioning and build is also done as part of this script. Run the "03_Run_UWC.sh" script after running the "02_provision_build_UWC.sh" script. This will bring up all the containers of the new use case.

--- a/source/Pages/page_04.rst
+++ b/source/Pages/page_04.rst
@@ -2,20 +2,20 @@
 4.0  Installation Guide
 =======================
 
----------------------------------------------------
-4.1  How to install UWC software with EII installer
----------------------------------------------------
+-------------------------------------------------------------------
+4.1  How to install Universal Wellpad Controller with EII installer
+-------------------------------------------------------------------
 
-This section provides steps to install and Deploy UWC containers using the EII installer
+This section provides steps to install and deploy Universal Wellpad Controller containers using the EII installer.
 
-**Pre-requisite**: Internet connection (with proper proxy settings) is required for Installation.
+**Prerequisite**: As a prerequisite to install the Universal Wellpad Controller, you need an internet connection with correct proxy settings.
 
-**Optional**: For enabling full security for production deployments, make sure host machine and docker daemon are configured with below security recommendations.       ../build/docker_security_recommendation.md
+**Optional**: For enabling full security for production deployments, ensure to configure host machine and docker daemon with the following security recommendations.       ../build/docker_security_recommendation.md
 
 **Steps:**
 
-1.	Install Ubuntu 20.04 server version on gateway and Apply RT Patch (refer section 14).
-2.	Git clone in following order will place the directories in proper relative directory  structure
+1. Install Ubuntu 20.04 server version on gateway and then, apply the RT Patch. For more information, see section 14.
+2. Git clone in following order will place the directories in the correct relative directory structure
 
 .. code-block:: sh
 
@@ -23,47 +23,49 @@ This section provides steps to install and Deploy UWC containers using the EII i
     •	repo init -m uwc.xml
     •	repo sync
 
-3.	Navigate to $ <working_dir>/IEdgeInsights/build
-
-
-4.	Execute Command 
-
-.. code-block:: sh
-
-    a.	$./pre_requisites.sh --proxy=<proxy address with port number> for proxy enabled network.
-
-    b.	$ sudo ./pre_requisites.sh – for non-proxy network
-
+3. Navigate to the build folder from the following path <working_dir>/IEdgeInsights/build
+4. Based on the proxy settings, run any of the following commands:
+   
+   * For a proxy enabled network, run ./pre_requisites.sh --proxy=<proxy address with port number>
+   * For a non-proxy network, run sudo ./pre_requisites.sh 
 
 .. note::
        
-    If the error "Docker CE installation step is failed" is seen while running pre-requisite.sh script on a fresh system then kindly re-run the pre_requisite.sh script again. This is a known bug in docker community for Docker CE.
+    Rerun the pre_requisite.sh script, if the "Docker CE installation step is failed" error occurs while running the pre-requisite.sh script on a fresh system. This is a known bug in the docker community for Docker CE.
 
-5.	Navigate to <working_dir>/IEdgeInsights/uwc/build_scripts.   
-6.	Execute Command $ sudo -E ./01_uwc_pre_requisites.sh
-7.	Execute Command $ sudo -E ./02_provision_build_UWC.sh
+5. Navigate to ``<working_dir>/IEdgeInsights/uwc/build_scripts``.   
+6. Run the following command:
 
-It prompts these options – 
+.. code-block:: sh
+ 
+ sudo -E ./01_uwc_pre_requisites.sh
+    
+7. Run the following command:
 
-•	Please choose one of the below options based on Dev or Prod mode.
-    1) Dev
-    2) Prod 
-•	Please choose one of the below options based on the use case (combination of UWC services) needed.
-    1) Basic UWC micro-services without KPI-tactic Application & Sparkplug-Bridge - (Modbus-master TCP & RTU, mqtt-bridge, internal mqtt broker, ETCD server, ETCD UI &        other base EII & UWC services)
-    2) Basic UWC micro-services as in option 1 along with KPI-tactic Application (Without Sparkplug-Bridge)
-    3) Basic UWC micro-services & KPI-tactic Application along with Sparkplug-Bridge, Sample SamplePublisher and Sample SampleSubscriber
-    4) Basic UWC micro-services with Sparkplug-Bridge, Sample SamplePublisher and Sample SampleSubscriber and no KPI-tactic Application
-    5) Basic UWC micro-services with Time series micro-services (Telegraf & InfluxDBConnector)
-    6) Running Basic UWC micro-services with time series services (Telegraf & InfluxDBCOnnector) along with KPI-tactic app
-    7) Running Basic UWC micro-services with time series services (Telegraf & InfluxDBCOnnector) along with Sparkplug service, Sample SamplePublisher and Sample              SampleSubscriber
-    8) Running the Sample DB publisher with Telegraf, InfluxDBCOnnector, ZmqBroker & Etcd container.
-    9) Basic UWC micro-services with Sample SamplePublisher and Sample SampleSubscriber.
-    10) All modules UWC modules, KPI-tactic Application, SPARKPLUG-BRIDGE, Telegraf, InfluxDBCOnnector, ZmqBroker, Etcd container, Sample SamplePublisher and Sample           SampleSubscriber
-•	Do you want to use pre-build images from public docker hub ?
-    1) Yes  
-    2) No
+.. code-block:: sh
 
-Following is a sample output for Sparkplug-Bridge related configuration:
+ sudo -E ./02_provision_build_UWC.sh
+
+8. Select one of the following options based on Dev mode or Prod mode.
+   - Dev
+   - Prod 
+9. Based on the use case (combination of Universal Wellpad Controller services), select one of the following options: 
+
+   - Basic UWC micro-services without KPI-tactic Application & Sparkplug-Bridge - (Modbus-master TCP & RTU, mqtt-bridge, internal mqtt broker, ETCD server, ETCD UI &        other base EII & UWC services)
+   - Basic UWC micro-services as in option 1 along with KPI-tactic Application (Without Sparkplug-Bridge)
+   - Basic UWC micro-services & KPI-tactic Application along with Sparkplug-Bridge, Sample SamplePublisher and Sample SampleSubscriber
+   - Basic UWC micro-services with Sparkplug-Bridge, Sample SamplePublisher and Sample SampleSubscriber and no KPI-tactic Application
+   - Basic UWC micro-services with Time series micro-services (Telegraf & InfluxDBConnector)
+   - Running Basic UWC micro-services with time series services (Telegraf & InfluxDBCOnnector) along with KPI-tactic app
+   - Running Basic UWC micro-services with time series services (Telegraf & InfluxDBCOnnector) along with Sparkplug service, Sample SamplePublisher and Sample              SampleSubscriber
+   - Running the Sample DB publisher with Telegraf, InfluxDBCOnnector, ZmqBroker & Etcd container
+   - Basic UWC micro-services with Sample SamplePublisher and Sample SampleSubscriber
+   - All modules UWC modules, KPI-tactic Application, SPARKPLUG-BRIDGE, Telegraf, InfluxDBCOnnector, ZmqBroker, Etcd container, Sample SamplePublisher and Sample           SampleSubscriber
+*	Do you want to use pre-build images from public docker hub ?
+    - Yes  
+    - No
+
+For the Sparkplug-Bridge-related configuration, refer to the following sample output:
 
 **• Enter the following parameters required for Sparkplug-Bridge container..**
 
@@ -93,47 +95,54 @@ Enter the external broker port number:
 Enter the QOS for scada (between 0 to 2): 
     1
 
-8.	Execute Command $ sudo -E ./03_Run_UWC.sh
+10.	Run the following command:
 
-Above is a process for interactive mode. A non-interactive mode is also supported. 
-Following are the details: 
+.. code-block:: sh
 
-9. To support non-interactive mode, following options are added in 2nd script(02_provision_build_UWC.sh).
+sudo -E ./03_Run_UWC.sh
+
+.. note::
+
+    These steps are the process for interactive mode. For a non-interactive mode support, refer to the following steps
+
+11. To support non-interactive mode, the following options are added in the 2nd script (02_provision_build_UWC.sh).
 
 .. figure:: Doc_Images/table8.PNG
     :scale: 80 %
     :align: center
 
 
-If required parameters are missing, then those will be requested from user in an interactive mode.
+If the required parameters are not available, then in the interactive mode, you need to provide the details for the required parameters.
+12.	Following are sample commands for the non-interactive mode execution.
 
-10.	Following are sample commands for non-interactive mode execution.
+    * For all the Universal Wellpad Controller basic modules (no KPI, no Sparkplug-Bridge), run the following command:
 
-.. code-block:: sh
-
-        All UWC basic modules (no KPI, no Sparkplug-Bridge)
-        sudo -E ./02_provision_build_UWC.sh --deployMode=dev --recipe=1
-
-        All UWC modules (with KPI and with Sparkplug-Bridge).
-        sudo -E ./02_provision_build_UWC.sh --deployMode=dev --recipe=3 --isTLS=yes --caFile="scada_ext_certs/ca/root-ca.crt" --crtFile="scada_ext_certs/client/client.crt" --keyFile="scada_ext_certs/client/client.key" --brokerAddr="192.168.1.11" --brokerPort=22883 --qos=1
-
-
-Build scripts descriptions– 
-
-    1.	01_uwc_pre_requisites.sh - This script creates docker volume directory /opt/intel/eii/uwc_data, creates “/opt/intel/eii/container_logs/” for storing log and git clone modconn into respective directory of modbus master container.  
+.. code-block:: sh    
     
-    2.	02_provision_build_UWC.sh - It runs the builder to generate consolidated docker-compose.yml. This script performs provisioning as per docker-compose.yml file. Along with this, it generates certs for mqtt and Builds all the micro-services of the docker-compose.yml.
-        It allows user to choose combination of UWC services, allows to choose deployment mode either dev or prod mode or allows to choose whether to use `pre-build images` or `build images locally`.
+      sudo -E ./02_provision_build_UWC.sh --deployMode=dev --recipe=1
 
-    3.	03_Run_UWC.sh - This script deploys all UWC containers.
+    * For all the Universal Wellpad Controller modules (with KPI and with Sparkplug-Bridge).
+    
+.. code-block:: sh 
+ 
+      sudo -E ./02_provision_build_UWC.sh --deployMode=dev --recipe=3 --isTLS=yes --caFile="scada_ext_certs/ca/root-ca.crt" --crtFile="scada_ext_certs/client/client.crt" --keyFile="scada_ext_certs/client/client.key" --brokerAddr="192.168.1.11" --brokerPort=22883 --qos=1
 
-    4.	04_uninstall_UWC.sh – Used for cleanup and uninstalling docker, docker-compose and installed libraries. This script will bring down all containers and removes all running containers.
 
-    5.	05_applyConfigChanges.sh - This script will stop and start all running containers with updated changes.
+Build scripts descriptions
 
-    6.	06_UnitTestRun.sh - This script will generate unit test report and code coverage report.
+    1. 01_uwc_pre_requisites.sh - This script creates docker volume directory /opt/intel/eii/uwc_data, creates “/opt/intel/eii/container_logs/” for storing log, and git clone modconn into respective directory of the Modbus master container.  
+    
+    2. 02_provision_build_UWC.sh - This script runs the builder to generate the consolidated docker-compose.yml. This script performs provisioning per the docker-compose.yml file. Along with this, it generates certs for the MQTT and builds all the microservices of the docker-compose.yml.
+        It allows you to choose combination of UWC services, deployment mode either dev or prod mode, or select whether to use the `pre-build images` or `build images locally`.
+
+    3. 03_Run_UWC.sh - This script deploys all UWC containers.
+
+    4. 04_uninstall_UWC.sh – Used for cleanup and uninstalling docker, docker-compose, and installed libraries. This script will bring down all containers and remove all running containers.
+
+    5. 05_applyConfigChanges.sh - This script will stop and start all running containers with updated changes.
+
+    6. 06_UnitTestRun.sh - This script will generate unit test report and code coverage report.
 
 .. note::
 
-While a particular usecase is running & if user intends to change the usecase, then the script "./02_provision_build_UWC.sh" has to be re-run. This would kill (remove) all the containers of the existing use case & re-create the consolidated docker-compose.yml & consolidated eii_config.json file as per the new use case selected in "./02_provision_build_UWC.sh". Provisioning is also done as part of this script.
-"03_Run_UWC.sh" script should be executed  post "02_provision_build_UWC.sh" is run, which would build the containers of the newly selected usecase.
+To change the use case that is running, then rerun the "./02_provision_build_UWC.sh" script. This will remove or kill all the containers of the existing use case and recreate the consolidated docker-compose.yml and consolidated eii_config.json file per the new use case selected in the "./02_provision_build_UWC.sh" script. Provisioning is also done as part of this script. Run the "03_Run_UWC.sh" script after running the "02_provision_build_UWC.sh" script. This will build the containers of the new use case.


### PR DESCRIPTION
Global comment: Please comply with the guidelines provided in the Intel-Names Database for the usage and name of the Universal Wellpad Controller. See, https://prod-namesdb.intel.com/ 
The abbreviation for Universal Wellpad Controller should be expanded in the menu options of the software. After this change is implemented we can align the documentation as well. FYR see lines 52 to 61.

Also, in the menu options, micro-services should be rectified to microservices. Hyphen is not required for 'microservices'.